### PR TITLE
# GenericSecureTcpIpServer

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/GenericSecureTcpIpServer.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericSecureTcpIpServer.cs
@@ -759,28 +759,39 @@ namespace PepperDash.Core
                 else
                 {
                     Debug.Console(1, this, Debug.ErrorLogLevel.Error, "Client attempt faulty.");
-                    if (!ServerStopped)
-                    {
-                        server.WaitForConnectionAsync(IPAddress.Any, SecureConnectCallback);
-                        return;
-                    }
+					
+					// JTA 2020-02-20 
+					// There is an issue where on a failed negotiation we need to stop and start the server. This should still leave connected client intact. 
+					server.Stop();
+					Listen();
+                    return;
+                    
                 }
             }
             catch (Exception ex)
             {
                 Debug.Console(2, this, Debug.ErrorLogLevel.Error, "Error in Socket Status Connect Callback. Error: {0}", ex);
             }
-            //Debug.Console(1, this, Debug.ErrorLogLevel, "((((((Server State bitfield={0}; maxclient={1}; ServerStopped={2}))))))",
-            //    server.State, 
-            //    MaxClients,
-            //    ServerStopped);
-            if ((server.State & ServerState.SERVER_LISTENING) != ServerState.SERVER_LISTENING && MaxClients > 1 && !ServerStopped)
-            {
-                Debug.Console(1, this, Debug.ErrorLogLevel.Notice, "Waiting for next connection");
-                server.WaitForConnectionAsync(IPAddress.Any, SecureConnectCallback);
 
-            }
-        }
+			server.WaitForConnectionAsync(IPAddress.Any, SecureConnectCallback);
+
+			/*
+			Debug.Console(1, this, Debug.ErrorLogLevel.Error, "((((((Server State ={0} {3}; maxclient={1}; ServerStopped={2}))))))",
+			  server.State, 
+			  MaxClients,
+			  ServerStopped);
+			 
+			// JTA 2020-02-21 Im was not clear on why this condition was here. I think the WaitForCOnnection should always rearm.
+			
+			if ((server.State & ServerState.SERVER_LISTENING) != ServerState.SERVER_LISTENING && MaxClients > 1 && !ServerStopped)
+			{
+				Debug.Console(1, this, Debug.ErrorLogLevel.Notice, "Waiting for next connection");
+				server.WaitForConnectionAsync(IPAddress.Any, SecureConnectCallback);
+
+			}
+			*/
+
+		}
 
         #endregion
 

--- a/Pepperdash Core/Pepperdash Core/PepperDash_Core.csproj
+++ b/Pepperdash Core/Pepperdash Core/PepperDash_Core.csproj
@@ -49,19 +49,19 @@
     <Reference Include="mscorlib" />
     <Reference Include="SimplSharpCustomAttributesInterface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpCustomAttributesInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpCustomAttributesInterface.dll</HintPath>
     </Reference>
     <Reference Include="SimplSharpHelperInterface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpHelperInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpHelperInterface.dll</HintPath>
     </Reference>
     <Reference Include="SimplSharpNewtonsoft, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpNewtonsoft.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpNewtonsoft.dll</HintPath>
     </Reference>
     <Reference Include="SimplSharpReflectionInterface, Version=1.0.5583.25238, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpReflectionInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpReflectionInterface.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
- Restarts the server whenever a faulty client connection occurs. This appears the only way to get the listener back after a faulty attempt.
- Removes the condition on rearming the server.WaitForConnectionAsync callback.
#8 