### PR TITLE
Fix issue with ssh connections dropping

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
@@ -243,7 +243,7 @@ namespace PepperDash.Core
             try
             {
                 Client.Connect();
-                TheStream = Client.CreateShellStream("PDTShell", 100, 80, 100, 200, 100000);
+                TheStream = Client.CreateShellStream("PDTShell", 100, 80, 100, 200, 65534);
                 TheStream.DataReceived += Stream_DataReceived;
                 //TheStream.ErrorOccurred += TheStream_ErrorOccurred;
                 Debug.Console(1, this, "Connected");

--- a/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
@@ -13,6 +13,7 @@ namespace PepperDash.Core
 	/// </summary>
     public class GenericSshClient : Device, ISocketStatusWithStreamDebugging, IAutoReconnect
 	{
+	    private const string SPlusKey = "Uninitialized SshClient";
         public CommunicationStreamDebugging StreamDebugging { get; private set; }
 
 		/// <summary>
@@ -155,8 +156,9 @@ namespace PepperDash.Core
 		/// S+ Constructor - Must set all properties before calling Connect
 		/// </summary>
 		public GenericSshClient()
-			: base("Uninitialized SshClient")
+			: base(SPlusKey)
 		{
+            StreamDebugging = new CommunicationStreamDebugging(SPlusKey);
 			CrestronEnvironment.ProgramStatusEventHandler += new ProgramStatusEventHandler(CrestronEnvironment_ProgramStatusEventHandler);
 			AutoReconnectIntervalMs = 5000;
 		}
@@ -437,8 +439,11 @@ namespace PepperDash.Core
 
                 }
 			}
-			catch
+			catch (Exception ex)
 			{
+			    Debug.Console(0, "Exception: {0}", ex.Message);
+			    Debug.Console(0, "Stack Trace: {0}", ex.StackTrace);
+
 				Debug.Console(1, this, "Stream write failed. Disconnected, closing");
 				ClientStatus = SocketStatus.SOCKET_STATUS_BROKEN_REMOTELY;
 				HandleConnectionFailure();

--- a/Pepperdash Core/Pepperdash Core/Comm/GenericTcpIpClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericTcpIpClient.cs
@@ -15,7 +15,8 @@ namespace PepperDash.Core
     /// A class to handle basic TCP/IP communications with a server
     /// </summary>
 	public class GenericTcpIpClient : Device, ISocketStatusWithStreamDebugging, IAutoReconnect
-	{
+    {
+        private const string SplusKey = "Uninitialized TcpIpClient";
         public CommunicationStreamDebugging StreamDebugging { get; private set; }
 
 		/// <summary>
@@ -204,8 +205,9 @@ namespace PepperDash.Core
         /// Default constructor for S+
         /// </summary>
         public GenericTcpIpClient()
-			: base("Uninitialized TcpIpClient")
+			: base(SplusKey)
 		{
+            StreamDebugging = new CommunicationStreamDebugging(SplusKey);
 			CrestronEnvironment.ProgramStatusEventHandler += new ProgramStatusEventHandler(CrestronEnvironment_ProgramStatusEventHandler);
 			AutoReconnectIntervalMs = 5000;
             BufferSize = 2000;

--- a/Pepperdash Core/Pepperdash Core/Comm/GenericUdpServer.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericUdpServer.cs
@@ -17,6 +17,7 @@ namespace PepperDash.Core
 {
     public class GenericUdpServer : Device, ISocketStatusWithStreamDebugging
     {
+        private const string SplusKey = "Uninitialized Udp Server";
         public CommunicationStreamDebugging StreamDebugging { get; private set; }
         /// <summary>
         /// 
@@ -119,8 +120,9 @@ namespace PepperDash.Core
         /// Constructor for S+. Make sure to set key, address, port, and buffersize using init method
         /// </summary>
         public GenericUdpServer()
-            : base("Uninitialized Udp Server")
+            : base(SplusKey)
         {
+            StreamDebugging = new CommunicationStreamDebugging(SplusKey);
             BufferSize = 5000;
             DequeueLock = new CCriticalSection();
             MessageQueue = new CrestronQueue<GenericUdpReceiveTextExtraArgs>();


### PR DESCRIPTION
close #42 

Upon doing some testing, it was clarified that the issue happened when sending or receiving to a SSH Client. When `StreamDebugging` was added to address #25 it wasn't initialized in the constructors used by S+, causing a null ref exception to be thrown and resetting the connection. Initializing this from the S+ constructor solved the issue.