### PR TITLE
Add HTTP & WS comm methods to enum

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/eControlMethods.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/eControlMethods.cs
@@ -11,6 +11,6 @@ namespace PepperDash.Core
     /// </summary>
     public enum eControlMethod
     {
-        None = 0, Com, IpId, IpidTcp, IR, Ssh, Tcpip, Telnet, Cresnet, Cec, Udp
+        None = 0, Com, IpId, IpidTcp, IR, Ssh, Tcpip, Telnet, Cresnet, Cec, Udp, Http, Https, Ws, Wss
     }
 }


### PR DESCRIPTION
For now, adding these 4 methods (HTTP, HTTPS, WS, WSS) will prevent serialization exceptions if an attempt is made to serialize a control properties object that contains HTTP as a method.