### PR TITLE
Feature/env variable workflow updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         shell: powershell
         run: |
           $version = ./.github/scripts/GenerateVersionNumber.ps1
-          echo "VERSION=$version" | Out-File -FilePath $env::GITHUB_ENV -Encoding utf8 -Append
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       # Use the version number to set the version of the assemblies
       - name: Update AssemblyInfo.cs
         shell: powershell

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         shell: powershell
         run: |
           $version = ./.github/scripts/GenerateVersionNumber.ps1
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env::GITHUB_ENV -Encoding utf8 -Append
       # Use the version number to set the version of the assemblies
       - name: Update AssemblyInfo.cs
         shell: powershell
@@ -123,7 +123,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env::GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       - name: Download Build output

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,7 +123,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          echo "VERSION=$version" | Out-File -FilePath $env::GITHUB_ENV -Encoding utf8 -Append
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       - name: Download Build output
@@ -178,7 +178,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       # Checkout/Create the branch
@@ -255,7 +255,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       # Checkout/Create the branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         shell: powershell
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: Write-Output "::set-env name=VERSION::$($Env:TAG_NAME)"
+        run: echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       # Use the version number to set the version of the assemblies
       - name: Update AssemblyInfo.cs
         shell: powershell
@@ -98,7 +98,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       - name: Download Build output
@@ -152,7 +152,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       # Checkout/Create the branch
@@ -225,7 +225,7 @@ jobs:
           Get-ChildItem "./Version"
           $version = Get-Content -Path ./Version/version.txt
           Write-Host "Version: $version"
-          Write-Output "::set-env name=VERSION::$version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Remove-Item -Path ./Version/version.txt
           Remove-Item -Path ./Version
       # Checkout/Create the branch


### PR DESCRIPTION
close #67 

Updates `set-env` commands to use the new environment file writing method as described in [the documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)