### PR TITLE
Reduces error log messages from SSH client on basic disconnects

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
@@ -66,6 +66,7 @@ namespace PepperDash.Core
 		}
 
         private bool IsConnecting = false;
+        private bool DisconnectLogged = false;
 
 		/// <summary>
 		/// S+ helper for IsConnected
@@ -251,24 +252,28 @@ namespace PepperDash.Core
                 Debug.Console(1, this, Debug.ErrorLogLevel.Notice, "Connected");
                 ClientStatus = SocketStatus.SOCKET_STATUS_CONNECTED;
                 IsConnecting = false;
+                DisconnectLogged = false;
                 return; // Success will not pass here
             }
             catch (SshConnectionException e)
             {
                 var ie = e.InnerException; // The details are inside!!
+                var errorLogLevel = DisconnectLogged == true ? Debug.ErrorLogLevel.None : Debug.ErrorLogLevel.Error;
+
                 if (ie is SocketException)
-                    Debug.Console(1, this, Debug.ErrorLogLevel.Error, "'{0}' CONNECTION failure: Cannot reach host, ({1})", Key, ie.Message);
+                    Debug.Console(1, this, errorLogLevel, "'{0}' CONNECTION failure: Cannot reach host, ({1})", Key, ie.Message);
                 else if (ie is System.Net.Sockets.SocketException)
-                    Debug.Console(1, this, Debug.ErrorLogLevel.Error, "'{0}' Connection failure: Cannot reach host '{1}' on port {2}, ({3})",
+                    Debug.Console(1, this, errorLogLevel, "'{0}' Connection failure: Cannot reach host '{1}' on port {2}, ({3})",
                         Key, Hostname, Port, ie.GetType());
                 else if (ie is SshAuthenticationException)
                 {
-                    Debug.Console(1, this, Debug.ErrorLogLevel.Error, "Authentication failure for username '{0}', ({1})",
+                    Debug.Console(1, this, errorLogLevel, "Authentication failure for username '{0}', ({1})",
                         Username, ie.Message);
                 }
                 else
-                    Debug.Console(1, this, Debug.ErrorLogLevel.Error, "Error on connect:\r({0})", e);
+                    Debug.Console(1, this, errorLogLevel, "Error on connect:\r({0})", e);
 
+                DisconnectLogged = true;
                 ClientStatus = SocketStatus.SOCKET_STATUS_CONNECT_FAILED;
                 HandleConnectionFailure();
             }
@@ -335,7 +340,7 @@ namespace PepperDash.Core
 		            {
 		                Connect();
 		            }, AutoReconnectIntervalMs);
-		            Debug.Console(1, this, Debug.ErrorLogLevel.Notice, "Attempting connection in {0} seconds",
+		            Debug.Console(1, this, "Attempting connection in {0} seconds",
 		                (float) (AutoReconnectIntervalMs/1000));
 		        }
 		        else

--- a/Pepperdash Core/Pepperdash Core/Logging/Debug.cs
+++ b/Pepperdash Core/Pepperdash Core/Logging/Debug.cs
@@ -389,7 +389,10 @@ namespace PepperDash.Core
             string format, params object[] items)
         {
             var str = string.Format("[{0}] {1}", dev.Key, string.Format(format, items));
-			LogError(errorLogLevel, str);
+            if (errorLogLevel != ErrorLogLevel.None)
+            {
+                LogError(errorLogLevel, str);
+            }
             if (Level >= level)
             {
                 Console(level, str);
@@ -403,7 +406,10 @@ namespace PepperDash.Core
             string format, params object[] items)
         {
             var str = string.Format(format, items);
-            LogError(errorLogLevel, str);
+            if (errorLogLevel != ErrorLogLevel.None)
+            {
+                LogError(errorLogLevel, str);
+            }
 			if (Level >= level)
 			{
 				Console(level, str);


### PR DESCRIPTION
This reduces SSH client logging on basic disconnect issues. I've noticed error logs are getting full with errors due to logging on every reconnect attempt. Just because a device is offline, the error log should not fill with thousands of messages.

The two changes are:
1) No longer log the reconnect attempt. This still shows up in debug trace
2) Log only the first disconnect to the error log, then only print to debug. If the device connects, it will reset and allow the next disconnect to log to the error log.

To keep it clean, I added a check in the debug console method to check the error log level. If it is set to "ErrorLog.None" it won't log to the error log.