### PR TITLE
Feature/ssh dispose

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
@@ -290,6 +290,7 @@ namespace PepperDash.Core
 		/// </summary>
 		public void Disconnect()
 		{
+			Debug.Console(2, "Disconnect Called");
 			ConnectEnabled = false;
 			// Stop trying reconnects, if we are
 			if (ReconnectTimer != null)
@@ -307,11 +308,13 @@ namespace PepperDash.Core
         private void KillClient(SocketStatus status)
         {
             KillStream();
-
+			IsConnecting = false;
             if (Client != null)
             {
-                IsConnecting = false;
+				Client.ErrorOccurred -= Client_ErrorOccurred;
                 Client.Disconnect();
+				Client.Dispose();
+				
                 Client = null;
                 ClientStatus = status;
                 Debug.Console(1, this, "Disconnected");


### PR DESCRIPTION
Adds a more robust disposal and unsubscribing from events to the SSH Client KillClient method. @ngenovese11 was able to trap an issue where restarting an app could cause a thread abort. This fixes that issue. The issue may have also had problems reconnecting. Complete log attached for reference. 

[Crestron_03.log](https://github.com/PepperDash/PepperDashCore/files/9735574/Crestron_03.log)
