### PR TITLE
Add null check for SSH reconnect timer

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericSshClient.cs
@@ -229,7 +229,10 @@ namespace PepperDash.Core
                     Debug.Console(1, this, "Attempting connect");
 
                     // Cancel reconnect if running.
-                    ReconnectTimer.Stop();
+					if (ReconnectTimer != null)
+					{
+						ReconnectTimer.Stop();
+					}
 
                     // Cleanup the old client if it already exists
                     if (Client != null)


### PR DESCRIPTION
The null check was removed in commit [https://github.com/PepperDash/PepperDashCore/commit/b12e79804174880810c2aa9006e0d63574636b83](b12e798).

When the `Disconnect` method is used to disconnect a client and then a reconnect is attempted using the connect method, the `ReconnectTimer` is null, and so a null check is required to prevent a null ref exception from being thrown. This probably hasn't been an issue yet as later versions of Core haven't been used with Cisco Codecs. The Cisco Codec class calls `Disconnect` and then the `Connect` method if the login message isn't received in a timely manner from the codec, which revealed this issue.

This fix has been tested in the field.