### PR TITLE
fix: StreamDebugging in default constructor

### DIFF
--- a/Pepperdash Core/Pepperdash Core/Comm/GenericTcpIpClient.cs
+++ b/Pepperdash Core/Pepperdash Core/Comm/GenericTcpIpClient.cs
@@ -220,7 +220,8 @@ namespace PepperDash.Core
         /// </summary>
         public GenericTcpIpClient()
 			: base(SplusKey)
-		{
+        {
+            StreamDebugging = new CommunicationStreamDebugging(SplusKey);
 			CrestronEnvironment.ProgramStatusEventHandler += new ProgramStatusEventHandler(CrestronEnvironment_ProgramStatusEventHandler);
 			AutoReconnectIntervalMs = 5000;
             BufferSize = 2000;


### PR DESCRIPTION
- creates a StreamDebugging class with the default s+ key
- this shouldn't matter since in a simpl windows env you can't use console commands anyhow

closes #165 