### PR TITLE
Build for both .NET 6 & .NET Framework 4.7.2

### DIFF
--- a/src/Pepperdash Core/PepperDash_Core.csproj
+++ b/src/Pepperdash Core/PepperDash_Core.csproj
@@ -26,9 +26,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Library" Version="2.20.42" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Comm\._GenericSshClient.cs" />

--- a/src/Pepperdash Core/PepperDash_Core.csproj
+++ b/src/Pepperdash Core/PepperDash_Core.csproj
@@ -25,11 +25,6 @@
     <DocumentationFile>bin\4Series\$(Configuration)\PepperDashCore.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Library" Version="2.20.42" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2">
       <Aliases>Full</Aliases>

--- a/src/Pepperdash Core/PepperDash_Core.csproj
+++ b/src/Pepperdash Core/PepperDash_Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PepperDash.Core</RootNamespace>
     <AssemblyName>PepperDashCore</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6</TargetFrameworks>
     <Deterministic>false</Deterministic>
     <NeutralLanguage>en</NeutralLanguage>
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -30,7 +30,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Crestron.SimplSharp.SDK.Library" Version="2.19.35" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.Library" Version="2.20.42" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2">
       <Aliases>Full</Aliases>
     </PackageReference>

--- a/src/Pepperdash Core/PepperDash_Core.csproj
+++ b/src/Pepperdash Core/PepperDash_Core.csproj
@@ -29,6 +29,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Remove="Comm\._GenericSshClient.cs" />
     <Compile Remove="Comm\._GenericTcpIpClient.cs" />


### PR DESCRIPTION
PepperDash Core is now built targeting both .NET Framework 4.7.2 & .NET 6. This will allow Essentials to also be built targeting both .NET 6 & .NET Framework 4.7.2.