### PR TITLE
Multiple Updates for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+*.projectinfo

--- a/src/Pepperdash Core/Logging/Debug.cs
+++ b/src/Pepperdash Core/Logging/Debug.cs
@@ -21,6 +21,7 @@ namespace PepperDash.Core
     /// </summary>
     public static class Debug
     {
+        private static string LevelStoreKey = "ConsoleDebugLevel";
         private static Dictionary<uint, LogEventLevel> _logLevels = new Dictionary<uint, LogEventLevel>()
         {
             {0, LogEventLevel.Information },
@@ -101,7 +102,9 @@ namespace PepperDash.Core
 
         static Debug()
         {
-            _consoleLoggingLevelSwitch = new LoggingLevelSwitch(initialMinimumLevel: LogEventLevel.Information);
+            var defaultConsoleLevel = GetStoredLogEventLevel();
+
+            _consoleLoggingLevelSwitch = new LoggingLevelSwitch(initialMinimumLevel: defaultConsoleLevel);
             _consoleLoggingLevelSwitch.MinimumLevelChanged += (sender, args) =>
             {
                 Console(0, "Console debug level set to {0}", _consoleLoggingLevelSwitch.MinimumLevel);
@@ -184,6 +187,24 @@ namespace PepperDash.Core
             {
 
                 CrestronConsole.PrintLine("Initializing of CrestronLogger failed: {0}", e);
+            }
+        }
+
+        private static LogEventLevel GetStoredLogEventLevel()
+        {
+            try
+            {
+                var result = CrestronDataStoreStatic.GetLocalUintValue(LevelStoreKey, out uint logLevel);
+
+                if(result != CrestronDataStore.CDS_ERROR.CDS_SUCCESS || logLevel > 5 || logLevel < 0)
+                {
+                    return LogEventLevel.Information;
+                }
+
+                return _logLevels[logLevel];
+            } catch
+            {
+                return LogEventLevel.Information;
             }
         }
 

--- a/src/Pepperdash Core/Logging/Debug.cs
+++ b/src/Pepperdash Core/Logging/Debug.cs
@@ -133,10 +133,11 @@ namespace PepperDash.Core
                 .WriteTo.Sink(new DebugConsoleSink(new JsonFormatter(renderMessage: true)), levelSwitch: _consoleLoggingLevelSwitch)
                 .WriteTo.Sink(_websocketSink, levelSwitch: _websocketLoggingLevelSwitch)
                 .WriteTo.File(logFilePath,
+                    outputTemplate: "[{Timestamp}][{Level}][{Properties.Key}]{Message}{NewLine}",
                     rollingInterval: RollingInterval.Day,
                     restrictedToMinimumLevel: LogEventLevel.Debug,
                     retainedFileCountLimit: CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance ? 30 : 60
-                );
+                ); ;
 
             try
             {

--- a/src/Pepperdash Core/Logging/Debug.cs
+++ b/src/Pepperdash Core/Logging/Debug.cs
@@ -24,11 +24,11 @@ namespace PepperDash.Core
         private static Dictionary<uint, LogEventLevel> _logLevels = new Dictionary<uint, LogEventLevel>()
         {
             {0, LogEventLevel.Information },
-            {1, LogEventLevel.Warning },
-            {2, LogEventLevel.Error },
-            {3, LogEventLevel.Fatal },
-            {4, LogEventLevel.Debug },
-            {5, LogEventLevel.Verbose },
+            {3, LogEventLevel.Warning },
+            {4, LogEventLevel.Error },
+            {5, LogEventLevel.Fatal },
+            {1, LogEventLevel.Debug },
+            {2, LogEventLevel.Verbose },
         };
 
         private static Logger _logger;
@@ -104,7 +104,7 @@ namespace PepperDash.Core
             _consoleLoggingLevelSwitch = new LoggingLevelSwitch(initialMinimumLevel: LogEventLevel.Information);
             _consoleLoggingLevelSwitch.MinimumLevelChanged += (sender, args) =>
             {
-                Debug.Console(0, "Console debug level set to {0}", _consoleLoggingLevelSwitch.MinimumLevel);
+                Console(0, "Console debug level set to {0}", _consoleLoggingLevelSwitch.MinimumLevel);
             };
             _websocketLoggingLevelSwitch = new LoggingLevelSwitch(initialMinimumLevel: LogEventLevel.Verbose);
             _websocketSink = new DebugWebsocketSink(new JsonFormatter(renderMessage: true));
@@ -116,7 +116,7 @@ namespace PepperDash.Core
                 .WriteTo.Sink(_websocketSink, levelSwitch: _websocketLoggingLevelSwitch)
                 .WriteTo.File(@"\user\debug\global-log-{Date}.txt"
                     , rollingInterval: RollingInterval.Day
-                    , restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Debug)
+                    , restrictedToMinimumLevel: LogEventLevel.Debug)
                 .CreateLogger();
 
             // Get the assembly version and print it to console and the log
@@ -455,6 +455,7 @@ namespace PepperDash.Core
             if (!_logLevels.ContainsKey(level)) return;
 
             var logLevel = _logLevels[level];
+            
             _logger.Write(logLevel, format, items);
         }
 
@@ -464,8 +465,8 @@ namespace PepperDash.Core
 
             var logLevel = _logLevels[level];
             
-            var log = _logger.ForContext("Key", keyed.Key);
-            log.Write(logLevel, format, items);
+            var logger = _logger.ForContext("Key", keyed.Key);
+            logger.Write(logLevel, format, items);
         }
 
 

--- a/src/Pepperdash Core/Logging/DebugConsoleSink.cs
+++ b/src/Pepperdash Core/Logging/DebugConsoleSink.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace PepperDash.Core
 {
-    internal class DebugConsoleSink : ILogEventSink
+    public class DebugConsoleSink : ILogEventSink
     {
         private readonly ITextFormatter _textFormatter;
 

--- a/src/Pepperdash Core/Logging/DebugConsoleSink.cs
+++ b/src/Pepperdash Core/Logging/DebugConsoleSink.cs
@@ -20,19 +20,21 @@ namespace PepperDash.Core
 
         public void Emit(LogEvent logEvent)
         {
-            if (!Debug.IsRunningOnAppliance) return;
+            if (!Debug.IsRunningOnAppliance) return;            
 
-            CrestronConsole.PrintLine("[{0}][App {1}][Lvl {2}]: {3}", logEvent.Timestamp,
-                InitialParametersClass.ApplicationNumber,
-                logEvent.Level,
-                logEvent.RenderMessage());
+            string message = $"[{logEvent.Timestamp}][{logEvent.Level}][App {InitialParametersClass.ApplicationNumber}]{logEvent.RenderMessage()}";
+
+            if(logEvent.Properties.TryGetValue("Key",out var value) && value is ScalarValue sv && sv.Value is string rawValue)
+            {
+                message = $"[{logEvent.Timestamp}][{logEvent.Level}][App {InitialParametersClass.ApplicationNumber}][{rawValue}]: {logEvent.RenderMessage()}";
+            }
+
+            CrestronConsole.PrintLine(message);
         }
 
-        public DebugConsoleSink(ITextFormatter formatProvider)
+        public DebugConsoleSink(ITextFormatter formatProvider )
         {
-
             _textFormatter = formatProvider ?? new JsonFormatter();
-
         }
 
     }

--- a/src/Pepperdash Core/Logging/DebugCrestronLoggerSink.cs
+++ b/src/Pepperdash Core/Logging/DebugCrestronLoggerSink.cs
@@ -1,0 +1,29 @@
+﻿using Crestron.SimplSharp;
+using Crestron.SimplSharp.CrestronLogger;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace PepperDash.Core.Logging
+{
+    public class DebugCrestronLoggerSink : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent)
+        {
+            if (!Debug.IsRunningOnAppliance) return;
+
+            string message = $"[{logEvent.Timestamp}][{logEvent.Level}][App {InitialParametersClass.ApplicationNumber}]{logEvent.RenderMessage()}";
+
+            if (logEvent.Properties.TryGetValue("Key", out var value) && value is ScalarValue sv && sv.Value is string rawValue)
+            {
+                message = $"[{logEvent.Timestamp}][{logEvent.Level}][App {InitialParametersClass.ApplicationNumber}][{rawValue}]: {logEvent.RenderMessage()}";
+            }
+
+            CrestronLogger.WriteToLog(message, (uint)logEvent.Level);
+        }
+
+        public DebugCrestronLoggerSink()
+        {
+            CrestronLogger.Initialize(1, LoggerModeEnum.RM);
+        }
+    }
+}

--- a/src/Pepperdash Core/PepperDash_Core.csproj
+++ b/src/Pepperdash Core/PepperDash_Core.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />D
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle" Version="1.8.9" />

--- a/src/Pepperdash Core/PepperDash_Core.csproj
+++ b/src/Pepperdash Core/PepperDash_Core.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>PepperDash.Core</RootNamespace>
     <AssemblyName>PepperDashCore</AssemblyName>
     <TargetFrameworks>net472;net6</TargetFrameworks>
-    <Deterministic>false</Deterministic>
+    <Deterministic>true</Deterministic>
     <NeutralLanguage>en</NeutralLanguage>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <SignAssembly>False</SignAssembly>
@@ -13,9 +13,10 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PepperDash/PepperDashCore</RepositoryUrl>
     <PackageTags>crestron;4series;</PackageTags>
-    <Version>$(Version)</Version>
+    <Version>2.0.0-local</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <PackageOutputPath>../../package</PackageOutputPath>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -28,7 +29,7 @@
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http" />D
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle" Version="1.8.9" />


### PR DESCRIPTION
* Modified map between old Debug levels (0, 1, 2) and Serilog LogEventLevels to more accurately reflect their usage
* Updated the `appdebug` console command to allow for using either integers or the Serilog LogEventLevel strings. 
* Moved the CrestronLogger initialization and writing to a Serilog Sink and marked the `ConsoleWithLog` methods as obsolete
* Updated the path for the Serilog file sink to write to a folder for the particular slot that's writing the log, along with changing the path depending on if it's an appliance or a VC-4 server. We may want to explore changing the path again, as the files may disappear if a room is removed
* Updated the file sink to retain 30 days of log files at the `Debug` level on an appliance, and 60 days on a VC-4 server
* Updated the format of messages logged to the file