### PR TITLE
feat: add Errorlog sink

### DIFF
--- a/src/Pepperdash Core/Logging/Debug.cs
+++ b/src/Pepperdash Core/Logging/Debug.cs
@@ -134,7 +134,7 @@ namespace PepperDash.Core
                 .WriteTo.Sink(new DebugConsoleSink(new JsonFormatter(renderMessage: true)), levelSwitch: _consoleLoggingLevelSwitch)
                 .WriteTo.Sink(_websocketSink, levelSwitch: _websocketLoggingLevelSwitch)
                 .WriteTo.Sink(new DebugErrorLogSink(), LogEventLevel.Information)
-                .WriteTo.File(new CompactJsonFormatter(), logFilePath,
+                .WriteTo.File(new RenderedCompactJsonFormatter(), logFilePath,                                    
                     rollingInterval: RollingInterval.Day,
                     restrictedToMinimumLevel: LogEventLevel.Debug,
                     retainedFileCountLimit: CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance ? 30 : 60

--- a/src/Pepperdash Core/Logging/Debug.cs
+++ b/src/Pepperdash Core/Logging/Debug.cs
@@ -13,6 +13,7 @@ using Serilog.Events;
 using Serilog.Formatting.Json;
 using Crestron.SimplSharp.CrestronDataStore;
 using PepperDash.Core.Logging;
+using Serilog.Formatting.Compact;
 
 namespace PepperDash.Core
 {
@@ -132,12 +133,12 @@ namespace PepperDash.Core
                 .MinimumLevel.Verbose()
                 .WriteTo.Sink(new DebugConsoleSink(new JsonFormatter(renderMessage: true)), levelSwitch: _consoleLoggingLevelSwitch)
                 .WriteTo.Sink(_websocketSink, levelSwitch: _websocketLoggingLevelSwitch)
-                .WriteTo.File(logFilePath,
-                    outputTemplate: "[{Timestamp}][{Level}][{Properties.Key}]{Message}{NewLine}",
+                .WriteTo.Sink(new DebugErrorLogSink(), LogEventLevel.Information)
+                .WriteTo.File(new CompactJsonFormatter(), logFilePath,
                     rollingInterval: RollingInterval.Day,
                     restrictedToMinimumLevel: LogEventLevel.Debug,
                     retainedFileCountLimit: CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance ? 30 : 60
-                ); ;
+                );
 
             try
             {
@@ -580,6 +581,7 @@ namespace PepperDash.Core
         /// <param name="level"></param>
         /// <param name="format">Console format string</param>
         /// <param name="items">Object parameters</param>
+        [Obsolete("Use LogMessage methods")]
         public static void Console(uint level, string format, params object[] items)
         {
 
@@ -605,6 +607,7 @@ namespace PepperDash.Core
         /// <summary>
 		/// Logs to Console when at-level, and all messages to error log, including device key			
         /// </summary>
+        [Obsolete("Use LogMessage methods")]
         public static void Console(uint level, IKeyed dev, string format, params object[] items)
         {
             LogMessage(level, dev, format, items);
@@ -617,6 +620,7 @@ namespace PepperDash.Core
         /// Prints message to console if current debug level is equal to or higher than the level of this message. Always sends message to Error Log.
         /// Uses CrestronConsole.PrintLine.
         /// </summary>
+        [Obsolete("Use LogMessage methods")]
         public static void Console(uint level, IKeyed dev, ErrorLogLevel errorLogLevel,
             string format, params object[] items)
         {
@@ -643,6 +647,7 @@ namespace PepperDash.Core
         /// <summary>
         /// Logs to Console when at-level, and all messages to error log
         /// </summary>
+        [Obsolete("Use LogMessage methods")]
         public static void Console(uint level, ErrorLogLevel errorLogLevel,
             string format, params object[] items)
         {
@@ -694,6 +699,7 @@ namespace PepperDash.Core
         /// </summary>
         /// <param name="errorLogLevel"></param>
         /// <param name="str"></param>
+        [Obsolete("Use LogMessage methods")]
         public static void LogError(ErrorLogLevel errorLogLevel, string str)
         {
 

--- a/src/Pepperdash Core/Logging/DebugErrorLogSink.cs
+++ b/src/Pepperdash Core/Logging/DebugErrorLogSink.cs
@@ -1,0 +1,44 @@
+﻿using Crestron.SimplSharp;
+using Serilog.Core;
+using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PepperDash.Core.Logging
+{
+    public class DebugErrorLogSink : ILogEventSink
+    {
+        private Dictionary<LogEventLevel, Action<string>> _errorLogMap = new Dictionary<LogEventLevel, Action<string>>
+        {
+            { LogEventLevel.Verbose, (msg) => ErrorLog.Notice(msg) },
+            {LogEventLevel.Debug, (msg) => ErrorLog.Notice(msg) },
+            {LogEventLevel.Information, (msg) => ErrorLog.Notice(msg) },
+            {LogEventLevel.Warning, (msg) => ErrorLog.Warn(msg) },
+            {LogEventLevel.Error, (msg) => ErrorLog.Error(msg) },
+            {LogEventLevel.Fatal, (msg) => ErrorLog.Error(msg) }
+        };
+        public void Emit(LogEvent logEvent)
+        {
+            var programId = CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance
+                ? $"App {InitialParametersClass.ApplicationNumber}"
+                : $"Room {InitialParametersClass.RoomId}";
+
+            string message = $"[{logEvent.Timestamp}][{logEvent.Level}][{programId}]{logEvent.RenderMessage()}";
+
+            if (logEvent.Properties.TryGetValue("Key", out var value) && value is ScalarValue sv && sv.Value is string rawValue)
+            {
+                message = $"[{logEvent.Timestamp}][{logEvent.Level}][{programId}][{rawValue}]: {logEvent.RenderMessage()}";
+            }
+
+            if(!_errorLogMap.TryGetValue(logEvent.Level, out var handler))
+            {
+                return;
+            }
+
+            handler(message);
+        }
+    }
+}


### PR DESCRIPTION
* Added Crestron ErrorLog Sink. Levels are mapped per table below.
* Modified file format to use the `RenderedCompactJsonFormatter`, as that will give all of the properties that get added to a message as context.